### PR TITLE
feat: rename the EPUB to "Author - Title" when filing a book

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,11 @@ dead-ends:
 In each case you get the picker with an empty Hardcover column and every field
 editable.
 
-Two toggles in the footer, remembered between runs:
+Three toggles in the footer, remembered between runs:
 
 - **Keep backup**: leave a `.rebind.bak` copy of the original next to the book.
 - **Sort book**: move the file into your sorted library after applying (below).
+- **Rename file**: rename the book to `<Author, Surname-first> - <Title>.epub` (on by default), whether or not it's sorted - with **Sort book** off it's renamed in place.
 
 Hit **Apply** and Rebind rewrites the file. The library refreshes on its own. If you
 rebind the book you're reading, it offers to reopen so the new metadata takes effect.
@@ -208,10 +209,14 @@ and remembered per device. Then you pick the layout:
 - **Directly in this folder**: just move the file into the chosen folder
 - **Keep here**: don't move
 
-The `.sdr` sidecar (reading progress, bookmarks, highlights) travels with the book.
-Sort the book you're currently reading and Rebind relocates it and reopens it at the
-new path, position intact. Author folders are surname-first (e.g. `Herbert, Frank`),
-and folder names are sanitized for filesystem-illegal characters.
+With **Rename file** on (the default), the book is renamed to
+`<Author, Surname-first> - <Title>.epub`, keeping its original extension; turn it off to
+keep the source filename. Rename is independent of sorting: with **Sort book** off, the
+book is renamed in place in its current folder. The `.sdr` sidecar (reading progress,
+bookmarks, highlights) travels with the book and follows the new name. Rename or sort the
+book you're currently reading and Rebind relocates it and reopens it at the new path,
+position intact. Author folders and filenames are surname-first (e.g. `Herbert, Frank`),
+sanitized for filesystem-illegal characters.
 
 <p align="center">
   <img src="screenshots/sort-move-dialog.png" width="320" alt="The move prompt: file the book by Author/Title, directly in the folder, or keep it">

--- a/main.lua
+++ b/main.lua
@@ -112,6 +112,10 @@ function Rebind:keepBackup()
     return self.settings:nilOrTrue("keep_backup")
 end
 
+function Rebind:renameFile()
+    return self.settings:nilOrTrue("rename_file")
+end
+
 function Rebind:currentFile()
     if self.ui and self.ui.document and self.ui.document.file then
         return self.ui.document.file
@@ -546,6 +550,7 @@ function Rebind:_showDiff(file, current, book, Api)
         end,
         keep_backup = self:keepBackup(),
         move_to_sorted = self.settings:isTrue("move_after_rebind"),
+        rename_file = self:renameFile(),
         on_apply = function(changes, opts)
             opts = opts or {}
             local keep = opts.keep_backup
@@ -553,8 +558,13 @@ function Rebind:_showDiff(file, current, book, Api)
                 keep = self:keepBackup()
             end
             local move = opts.move_to_sorted == true
+            local rename = opts.rename_file
+            if rename == nil then
+                rename = self:renameFile()
+            end
             self.settings:saveSetting("keep_backup", keep)
             self.settings:saveSetting("move_after_rebind", move)
+            self.settings:saveSetting("rename_file", rename)
             self.settings:flush()
             self:_write(file, changes, keep, move)
         end,
@@ -587,7 +597,14 @@ end
 
 function Rebind:_afterRewrite(file, is_open_book, backup, move_enabled)
     if not move_enabled then
-        self:_finish(file, is_open_book, backup, nil)
+        if self:renameFile() then
+            local meta = Epub.read_metadata(file)
+            local authors = meta and meta.authors or {}
+            local title = meta and meta.title
+            self:_doMove(file, is_open_book, backup, Organize.dirname(file), authors, title, "flat")
+        else
+            self:_finish(file, is_open_book, backup, nil)
+        end
         return
     end
 
@@ -685,7 +702,7 @@ function Rebind:_doMove(file, is_open_book, backup, root, authors, title, struct
         self:_relocateOpenBook(file, root, authors, title, backup, structure)
         return
     end
-    local moved, moved_result = Organize.move(file, root, authors, title, structure)
+    local moved, moved_result = Organize.move(file, root, authors, title, structure, self:renameFile())
     if moved then
         UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
         UIManager:broadcastEvent(Event:new("BookMetadataChanged"))
@@ -703,7 +720,7 @@ function Rebind:_relocateOpenBook(file, root, authors, title, backup, structure)
     ui:handleEvent(Event:new("CloseConfigMenu"))
     ui:onClose(false)
 
-    local moved, moved_result = Organize.move(file, root, authors, title, structure)
+    local moved, moved_result = Organize.move(file, root, authors, title, structure, self:renameFile())
     if moved then
         UIManager:broadcastEvent(Event:new("InvalidateMetadataCache", file))
         UIManager:broadcastEvent(Event:new("BookMetadataChanged"))

--- a/rebind/organize.lua
+++ b/rebind/organize.lua
@@ -55,6 +55,20 @@ function Organize.basename(path)
     return path:match("[^/]+$") or path
 end
 
+function Organize.dirname(path)
+    return path:match("^(.*)/[^/]+$") or "."
+end
+
+function Organize.extension(filename)
+    return filename:match("%.[^.]+$") or ""
+end
+
+function Organize.filename(authors, title, source_filename)
+    local author = Organize.author_folder(authors)
+    local book_title = Organize.sanitize(title, "Unknown Title")
+    return author .. " - " .. book_title .. Organize.extension(source_filename)
+end
+
 function Organize.target_dir(root, authors, title, structure)
     root = root:gsub("/+$", "")
     if structure == "flat" then
@@ -65,8 +79,12 @@ function Organize.target_dir(root, authors, title, structure)
     return table.concat({ root, author_dir, title_dir }, "/")
 end
 
-function Organize.target_path(root, authors, title, source_filename, structure)
-    return Organize.target_dir(root, authors, title, structure) .. "/" .. source_filename
+function Organize.target_path(root, authors, title, source_filename, structure, rename)
+    local name = source_filename
+    if rename ~= false then
+        name = Organize.filename(authors, title, source_filename)
+    end
+    return Organize.target_dir(root, authors, title, structure) .. "/" .. name
 end
 
 local function move_file(from, to)
@@ -82,12 +100,12 @@ local function move_file(from, to)
     return true
 end
 
-function Organize.move(source_path, root, authors, title, structure)
+function Organize.move(source_path, root, authors, title, structure, rename)
     local util = require("util")
     local lfs = require("libs/libkoreader-lfs")
     local DocSettings = require("docsettings")
 
-    local dest = Organize.target_path(root, authors, title, Organize.basename(source_path), structure)
+    local dest = Organize.target_path(root, authors, title, Organize.basename(source_path), structure, rename)
     if dest == source_path then
         return true, dest
     end

--- a/rebind/ui/diffpicker.lua
+++ b/rebind/ui/diffpicker.lua
@@ -64,6 +64,7 @@ local DiffPicker = InputContainer:extend{
     new_label = nil,
     keep_backup = nil,
     move_to_sorted = nil,
+    rename_file = nil,
     edition_label = nil,
     on_choose_edition = nil,
     translate_targets = nil,
@@ -82,6 +83,9 @@ function DiffPicker:init()
     end
     if self.move_to_sorted == nil then
         self.move_to_sorted = false
+    end
+    if self.rename_file == nil then
+        self.rename_file = true
     end
 
     if Device:hasKeys() then
@@ -608,13 +612,49 @@ function DiffPicker:_build()
             self:_refresh()
         end,
     }
+    local rename_info_btn = Button:new{
+        icon = "info",
+        icon_width = sc(18),
+        icon_height = sc(18),
+        radius = sc(4),
+        padding = sc(8),
+        bordersize = Size.border.button,
+        show_parent = self,
+        callback = function()
+            UIManager:show(InfoMessage:new{
+                text = _("Rename the book file to:\n\nAuthor, Surname-first - Title.epub\n\nExample:\nHerbert, Frank - Dune.epub\n\nThe original extension is kept. With Sort book off, the file is renamed in place."),
+            })
+        end,
+    }
+    local rename_btn = Button:new{
+        text = self.rename_file and _("Rename file: On") or _("Rename file: Off"),
+        radius = sc(4),
+        padding = sc(8),
+        bordersize = Size.border.button,
+        width = content_inner - rename_info_btn:getSize().w - sc(8),
+        show_parent = self,
+        callback = function()
+            self.rename_file = not self.rename_file
+            self:_refresh()
+        end,
+    }
     local toggles = FrameContainer:new{
         bordersize = 0,
         padding = Size.padding.default,
-        HorizontalGroup:new{
-            backup_btn,
-            HorizontalSpan:new{ width = sc(8) },
-            move_btn,
+        VerticalGroup:new{
+            align = "left",
+            HorizontalGroup:new{
+                backup_btn,
+                HorizontalSpan:new{ width = sc(8) },
+                move_btn,
+            },
+            VerticalSpan:new{ width = sc(6) },
+            HorizontalGroup:new{
+                align = "center",
+                rename_btn,
+                HorizontalSpan:new{ width = sc(8) },
+                rename_info_btn,
+            },
         },
     }
     local action_bar = FrameContainer:new{
@@ -715,6 +755,7 @@ function DiffPicker:_apply()
         self.on_apply(changes, {
             keep_backup = self.keep_backup,
             move_to_sorted = self.move_to_sorted,
+            rename_file = self.rename_file,
         })
     end
 end

--- a/tests/organize_spec.lua
+++ b/tests/organize_spec.lua
@@ -45,24 +45,41 @@ T["author_folder uses the first author, surname-first"] = function(a)
     a.eq(Organize.author_folder({}), "Unknown Author")
 end
 
-T["target_path builds root/Author/Title/filename"] = function(a)
+T["target_path builds root/Author/Title/Author - Title.ext"] = function(a)
     local p = Organize.target_path("/books/Sorted", { "Frank Herbert" }, "Dune", "dune.epub")
-    a.eq(p, "/books/Sorted/Herbert, Frank/Dune/dune.epub")
+    a.eq(p, "/books/Sorted/Herbert, Frank/Dune/Herbert, Frank - Dune.epub")
 end
 
 T["target_path strips a trailing slash from the root"] = function(a)
     local p = Organize.target_path("/books/Sorted/", { "Isaac Asimov" }, "Foundation", "f.epub")
-    a.eq(p, "/books/Sorted/Asimov, Isaac/Foundation/f.epub")
+    a.eq(p, "/books/Sorted/Asimov, Isaac/Foundation/Asimov, Isaac - Foundation.epub")
 end
 
 T["target_path sanitizes a title with a slash"] = function(a)
     local p = Organize.target_path("/r", { "A B" }, "Vol 1/2", "x.epub")
-    a.eq(p, "/r/B, A/Vol 1_2/x.epub")
+    a.eq(p, "/r/B, A/Vol 1_2/B, A - Vol 1_2.epub")
+end
+
+T["target_path keeps the original filename when rename is off"] = function(a)
+    local p = Organize.target_path("/books/Sorted", { "Frank Herbert" }, "Dune", "dune.epub", "nested", false)
+    a.eq(p, "/books/Sorted/Herbert, Frank/Dune/dune.epub")
 end
 
 T["basename returns the final path component"] = function(a)
     a.eq(Organize.basename("/a/b/c/book.epub"), "book.epub")
     a.eq(Organize.basename("book.epub"), "book.epub")
+end
+
+T["dirname returns the parent directory"] = function(a)
+    a.eq(Organize.dirname("/a/b/c/book.epub"), "/a/b/c")
+    a.eq(Organize.dirname("/books/dune.epub"), "/books")
+    a.eq(Organize.dirname("book.epub"), ".")
+end
+
+T["a flat move into the source folder renames in place"] = function(a)
+    local dir = Organize.dirname("/books/incoming/assassin.epub")
+    local p = Organize.target_path(dir, { "Robin Hobb" }, "Assassin's Apprentice", "assassin.epub", "flat")
+    a.eq(p, "/books/incoming/Hobb, Robin - Assassin's Apprentice.epub")
 end
 
 T["target_dir omits the filename"] = function(a)
@@ -71,12 +88,33 @@ end
 
 T["flat structure moves the file directly into the root"] = function(a)
     a.eq(Organize.target_dir("/r/", { "Frank Herbert" }, "Dune", "flat"), "/r")
-    a.eq(Organize.target_path("/r", { "Frank Herbert" }, "Dune", "d.epub", "flat"), "/r/d.epub")
+    a.eq(Organize.target_path("/r", { "Frank Herbert" }, "Dune", "d.epub", "flat"),
+        "/r/Herbert, Frank - Dune.epub")
 end
 
 T["nested is the default structure"] = function(a)
     a.eq(Organize.target_path("/r", { "Frank Herbert" }, "Dune", "d.epub"),
         Organize.target_path("/r", { "Frank Herbert" }, "Dune", "d.epub", "nested"))
+end
+
+T["extension returns the trailing extension"] = function(a)
+    a.eq(Organize.extension("dune.epub"), ".epub")
+    a.eq(Organize.extension("a.b.epub"), ".epub")
+    a.eq(Organize.extension("noext"), "")
+end
+
+T["filename builds Author - Title.ext, surname first"] = function(a)
+    a.eq(Organize.filename({ "Frank Herbert" }, "Dune", "dune.epub"), "Herbert, Frank - Dune.epub")
+    a.eq(Organize.filename({ "Frank Herbert", "Kevin J. Anderson" }, "Dune", "d.epub"),
+        "Herbert, Frank - Dune.epub")
+end
+
+T["filename sanitizes illegal characters in the title"] = function(a)
+    a.eq(Organize.filename({ "A B" }, "Vol: 1/2", "x.epub"), "B, A - Vol_ 1_2.epub")
+end
+
+T["filename falls back for missing author and title"] = function(a)
+    a.eq(Organize.filename({}, nil, "x.epub"), "Unknown Author - Unknown Title.epub")
 end
 
 return T


### PR DESCRIPTION
## What

After a rebind, name the file `<Author, Surname-first> - <Title>.epub`, keeping its original extension. A **Rename file** toggle in the picker controls it (**on by default**), with an ⓘ info icon that explains the naming scheme.

Rename is **independent of sorting**:

| Sort book | Rename file | Result |
|---|---|---|
| off | **on** | renamed in place in its current folder |
| off | off | metadata only, filename untouched |
| on | on | moved into the sorted tree **and** renamed |
| on | off | moved, original filename kept |

Both paths reuse the existing move machinery, so the `.sdr` sidecar (progress, bookmarks, highlights) follows the new name and the open book reopens at the new path. Collisions are refused rather than overwriting; an already-correctly-named file is a safe no-op.

## Changes

- `rebind/organize.lua`: `extension`, `filename` (surname-first `Author - Title.ext`), `dirname`, and a `rename` flag on `target_path`/`move`.
- `main.lua`: `renameFile` setting (on by default), rename-in-place when Sort is off, threaded through both move call sites.
- `rebind/ui/diffpicker.lua`: the **Rename file** toggle + info icon.
- Tests for `extension`, `filename`, `dirname`, rename-on/off, and in-place rename.
- README updated.

## Test plan

- `make test` - 135/135 pass.
- Parses under luajit.
- Manual: rebind a book with Sort off / Rename on and confirm it becomes `Author - Title.epub` in place; tap the ⓘ to see the explanation.